### PR TITLE
Feat: Add Projects Section to Portfolio

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
                     <ul class="nav-links">
                         <li><a href="#about" data-lang-en="About" data-lang-id="Tentang Saya"></a></li>
                         <li><a href="#services" data-lang-en="Services" data-lang-id="Layanan"></a></li>
+                        <li><a href="#projects" data-lang-en="Projects" data-lang-id="Proyek"></a></li>
                         <li><a href="#skills" data-lang-en="Skills" data-lang-id="Kemampuan"></a></li>
                         <li><a href="#contact" data-lang-en="Contact" data-lang-id="Kontak"></a></li>
                     </ul>
@@ -142,6 +143,63 @@
                     <h3 class="service-title" data-lang-en="Programming for Beginners" data-lang-id="Pemrograman untuk Pemula"></h3>
                     <p class="service-description" data-lang-en="Scratch & Python" data-lang-id="Scratch & Python"></p>
                 </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- ============================================ -->
+        <!--                    PROJECTS                  -->
+        <!-- ============================================ -->
+        <section id="projects">
+            <div class="container">
+                <h2 class="section-title" data-lang-en="My Projects" data-lang-id="Proyek Saya"></h2>
+                <div class="projects-grid">
+                    <!-- Project Card 1 -->
+                    <div class="project-showcase-card glass-card">
+                        <div class="project-image-container">
+                            <img src="https://via.placeholder.com/800x600.png/00ffb4/16161d?text=Project+Thumbnail" alt="Screenshot of Project 1" class="project-image">
+                        </div>
+                        <div class="project-content">
+                            <h3 class="project-showcase-title">Project Title One</h3>
+                            <p class="project-showcase-description"
+                               data-lang-en="A brief and engaging description of the project, what it does, the problem it solves, and the technologies used."
+                               data-lang-id="Deskripsi singkat dan menarik tentang proyek ini, apa fungsinya, masalah yang dipecahkan, dan teknologi yang digunakan.">
+                            </p>
+                            <ul class="project-tech-list">
+                                <li>Python</li>
+                                <li>Flask</li>
+                                <li>JavaScript</li>
+                                <li>PostgreSQL</li>
+                            </ul>
+                            <div class="project-links">
+                                <a href="#" class="btn btn-secondary" target="_blank" data-lang-en="Live Demo" data-lang-id="Demo Langsung"></a>
+                                <a href="#" class="btn btn-secondary" target="_blank" data-lang-en="Source Code" data-lang-id="Kode Sumber"></a>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- Project Card 2 -->
+                    <div class="project-showcase-card glass-card">
+                        <div class="project-image-container">
+                            <img src="https://via.placeholder.com/800x600.png/00ffb4/16161d?text=Project+Thumbnail" alt="Screenshot of Project 2" class="project-image">
+                        </div>
+                        <div class="project-content">
+                            <h3 class="project-showcase-title">Project Title Two</h3>
+                            <p class="project-showcase-description"
+                               data-lang-en="Another project description, highlighting different skills and challenges. This could be a mobile app, a data science project, or a web tool."
+                               data-lang-id="Deskripsi proyek lain, menyoroti keterampilan dan tantangan yang berbeda. Ini bisa berupa aplikasi seluler, proyek ilmu data, atau alat web.">
+                            </p>
+                            <ul class="project-tech-list">
+                                <li>Java</li>
+                                <li>Spring Boot</li>
+                                <li>React</li>
+                                <li>MongoDB</li>
+                            </ul>
+                            <div class="project-links">
+                                <a href="#" class="btn btn-secondary" target="_blank" data-lang-en="Live Demo" data-lang-id="Demo Langsung"></a>
+                                <a href="#" class="btn btn-secondary" target="_blank" data-lang-en="Source Code" data-lang-id="Kode Sumber"></a>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </section>

--- a/script.js
+++ b/script.js
@@ -207,6 +207,18 @@ document.addEventListener('DOMContentLoaded', function() {
             scrollTrigger: { trigger: '.services-grid', start: 'top 80%', toggleActions: 'play none none none' }
         });
 
+        gsap.from('.project-showcase-card', {
+            opacity: 0,
+            y: 50,
+            duration: 0.8,
+            stagger: 0.3,
+            scrollTrigger: {
+                trigger: '.projects-grid',
+                start: 'top 80%',
+                toggleActions: 'play none none none'
+            }
+        });
+
         gsap.from('.skills-column', {
             opacity: 0, x: -50, duration: 0.8,
             scrollTrigger: { trigger: '.skills-grid', start: 'top 80%', toggleActions: 'play none none none' }
@@ -426,5 +438,3 @@ document.addEventListener('DOMContentLoaded', function() {
     }
     mainLoop();
 });
-
-feather.replace();

--- a/style.css
+++ b/style.css
@@ -129,6 +129,19 @@ section { padding: calc(var(--spacing-unit) * 4) 0; }
     box-shadow: 0 10px 20px rgba(0, 255, 180, 0.2);
 }
 
+.btn.btn-secondary {
+    background: transparent;
+    border: 1px solid var(--color-accent-start);
+    color: var(--color-accent-start);
+    padding: 0.7rem 1.5rem;
+    font-size: 0.9rem;
+}
+
+.btn.btn-secondary:hover {
+    background: rgba(0, 255, 180, 0.1);
+    box-shadow: 0 5px 15px rgba(0, 255, 180, 0.15);
+}
+
 .social-icon {
     color: var(--color-text-secondary);
     text-decoration: none;
@@ -291,6 +304,74 @@ section { padding: calc(var(--spacing-unit) * 4) 0; }
 .service-title { font-family: var(--font-primary); font-size: 1.5rem; margin-bottom: 0.5rem; }
 .service-description { color: var(--color-text-secondary); font-size: 1rem; opacity: 0.9; }
 
+/* Projects Section */
+.projects-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: calc(var(--spacing-unit) * 3);
+}
+
+.project-showcase-card {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: calc(var(--spacing-unit) * 2);
+    align-items: center;
+}
+
+.project-showcase-card:nth-child(even) .project-image-container {
+    order: 2;
+}
+
+.project-image-container {
+    border-radius: var(--border-radius);
+    overflow: hidden;
+    line-height: 0;
+}
+
+.project-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.4s ease;
+}
+
+.project-showcase-card:hover .project-image {
+    transform: scale(1.05);
+}
+
+.project-showcase-title {
+    font-family: var(--font-primary);
+    font-size: 2rem;
+    margin-bottom: 1rem;
+}
+
+.project-showcase-description {
+    color: var(--color-text-secondary);
+    margin-bottom: 1.5rem;
+}
+
+.project-tech-list {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.7rem;
+    margin-bottom: 1.5rem;
+}
+
+.project-tech-list li {
+    background-color: rgba(0, 255, 180, 0.1);
+    color: var(--color-accent-start);
+    padding: 0.4rem 0.8rem;
+    border-radius: 20px;
+    font-size: 0.85rem;
+    font-weight: 500;
+}
+
+.project-links {
+    display: flex;
+    gap: 1rem;
+}
+
 /* Skills & Project Section */
 .skills-grid { display: grid; grid-template-columns: 1fr 1.2fr; gap: calc(var(--spacing-unit) * 2); align-items: start; }
 .skills-subtitle { font-family: var(--font-primary); margin-top: var(--spacing-unit); margin-bottom: 0.8rem; font-size: 1.5rem; }
@@ -334,7 +415,13 @@ section { padding: calc(var(--spacing-unit) * 4) 0; }
     .hamburger { display: block; background: none; border: none; cursor: pointer; }
     .hamburger-bar { display: block; width: 25px; height: 3px; margin: 5px auto; }
 
-    .services-grid, .skills-grid { grid-template-columns: 1fr; }
+    .services-grid, .skills-grid, .project-showcase-card, .project-showcase-card:nth-child(even) {
+        grid-template-columns: 1fr;
+    }
+
+    .project-showcase-card:nth-child(even) .project-image-container {
+        order: 0; /* Reset order for mobile */
+    }
 
     .nav-menu {
         position: absolute; top: 85px; left: 0;


### PR DESCRIPTION
This commit introduces a new "Projects" section to the portfolio website.

- Adds a new "Projects" section to `index.html` between the "Services" and "Skills" sections, populated with two placeholder project cards.
- Updates the navigation bar with a link to the new section.
- Adds CSS styles in `style.css` for the new section, ensuring a responsive layout that matches the existing "glassmorphism" design.
- Implements a scroll-triggered entrance animation for the project cards using GSAP in `script.js`.
- Removes an unused `feather.replace()` function call from `script.js`.